### PR TITLE
reconnects 5 seconds after a disconnect.

### DIFF
--- a/CollierUX/App.tsx
+++ b/CollierUX/App.tsx
@@ -1,6 +1,6 @@
 //import * as React from 'react';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 
 import * as SignalR from "@microsoft/signalr";
@@ -8,52 +8,81 @@ import RawLog from './Collier/RawLog';
 import StatsPanel from './Collier/Stats/StatsPanel';
 import PowerControl from './Collier/Stats/PowerControl';
 
-
 //TODO
-//  1. convert everything away from classes to function components
-//  2. That lets me use hooks or useContext.  useContext (and/or hooks) might be the correct way to
-//     handle passing the websocket to subcomponents and not use the context when the hotswap happens.
-//  3. DONE - refresh data on connect / reconnect 
-//  4. DONE - power button stat representation
-//  5. text selection from the UX doesn't work
-//  6. update notification for t-rex miner
-//  7. external configuration file
-//  8. update the read me and make a getting started guide
-//  9. power button clickable client side instead of starting / stopping service?  
+//  1. text selection from the UX doesn't work
+//  2. update notification for t-rex miner
+//  3. external configuration file
+//  4. update the read me and make a getting started guide
+//  5. power button clickable client side instead of starting / stopping service?  
 
 const CollierApp = () => {
   const hub_endpoint: string = 'http://localhost:9999/miner'; //TODO externalize to config
 
-  const connection: SignalR.HubConnection = new SignalR.HubConnectionBuilder()
-    .withUrl(hub_endpoint)
-    .configureLogging(SignalR.LogLevel.Debug)
-    .build();
+  //const connection: SignalR.HubConnection = 
+  const createConnection = (): SignalR.HubConnection => {
+    return new SignalR.HubConnectionBuilder()
+      .withUrl(hub_endpoint)
+      .configureLogging(SignalR.LogLevel.Debug)
+      .build();
+  };
 
+  //const [connection, setConnection] = useState(createConnection());
+  let connection: SignalR.HubConnection = createConnection();
+  const [webSocket, setWebSocket] = useState(connection);
 
   useEffect(() => {
+    let reconnectTimeout: number = 0;
 
-    connection.start().then(() => {
-      console.log(`Connected to ${hub_endpoint}`);
-    }).catch(err => {
-      console.log(`Error starting the connection: ${err.toString()}`)
-    });
+    const reconnect = () => {
+      if (reconnectTimeout === 0) {
+        const reconnectTime: number = 5000;  //TODO externalize to config
 
-    connection.onclose(async () => {
-      console.log(`Disconnected from ${hub_endpoint}`);
-    });
-  });
+        reconnectTimeout = +global.setTimeout(() => {
+          console.log(`Scheduling reconnect event in ${reconnectTime} ms.`);
+          connect();
+        }, reconnectTime);
+      }
+    };
+
+    const connect = () => {
+      if (webSocket.state != SignalR.HubConnectionState.Disconnected) {
+        console.info(`websocket already in a connected state ${webSocket.state}.  Aborting connect request.`);
+        reconnect();
+        return;
+      }
+
+      webSocket.start().then(() => {
+        console.log(`Connected to ${hub_endpoint}`);
+      }).catch(err => {
+        console.log(`Error starting the connection: ${err.toString()}`);
+        reconnect();
+      });
+
+      webSocket.onclose(() => {
+        console.log(`Disconnected from ${hub_endpoint}`);
+        reconnect();
+      });
+    }
+
+    connect();
+
+    return () => {
+      clearInterval(reconnectTimeout);
+      webSocket.stop();
+    }
+  }, []);
 
   return (
     <View style={{ marginBottom: 10, marginLeft: 10, marginRight: 10 }}>
-      <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderColor: "grey"}}>
+      <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderColor: "grey" }}>
         <View style={{ flex: 3, justifyContent: 'center', alignItems: 'center' }}>
-          <PowerControl websocket={connection}></PowerControl>
+          <PowerControl websocket={webSocket}></PowerControl>
         </View>
         <View style={{ flex: 7 }}>
-          <StatsPanel websocket={connection}></StatsPanel>
+          <StatsPanel websocket={webSocket}></StatsPanel>
         </View>
       </View>
-      <RawLog websocket={connection}></RawLog>
+      <RawLog websocket={webSocket}></RawLog>
     </View>
   );
 }


### PR DESCRIPTION
fixed excessive re-renders when attempting reconnects.

fixed hot-swapping during debug creating multiple web sockets which resulted in spam of 'method not found' messages in console when window service sent messages to sockets that had been unregistered from their listeners.